### PR TITLE
Add support for mount options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/*
 k8s_isi_provisioner
+.idea

--- a/README.md
+++ b/README.md
@@ -17,15 +17,37 @@ Building
 To build this provisioner, ensure you have go, and glide installed.  This code has been tested with Go 1.8 and higher.
 To build the software, run make.
 
-The provisioner requires permissions is you are running it in OpenShift (maybe Kubernetes it has not been tested in pure Kubernetes)
+The provisioner requires permissions if you are running it in OpenShift.
+```
 oc adm policy add-cluster-role-to-user system:persistent-volume-provisioner system:serviceaccount:k8s-isi-provisioner:default
+```
+It also requires pemissions if you're running in pure Kubernetes:
+```
+kubectl create -f auth.yaml
+```
 
-To deploy the provisioner, run 
+To deploy the provisioner, run
+```
 oc create -f pod.yaml
-Create a storage class using the class.yaml file 
+```
+Create a storage class using the class.yaml file
+```
 oc create -f class.yaml
+```
 
-To create a persistent volume, create a pvc and add an annotaion:
+Or in Kubernetes, run:
+```
+kubectl create -f pod.yaml
+kubectl create -f class.yaml
+```
+
+Some versions of Isilon may require the use of NFSv3. In that case, run:
+```
+kubectl create -f class-with-mount-options.yaml
+```
+
+
+To create a persistent volume, create a pvc and add an annotation:
 volume.beta.kubernetes.io/storage-class: "k8s-isilon"
 This will enable the automatic creation of a persistent volume.
 

--- a/auth.yaml
+++ b/auth.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-isi-provisioner
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: k8s-isi-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["nfs-provisioner"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: run-isi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: k8s-isi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: k8s-isi-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/class-with-mount-options.yaml
+++ b/class-with-mount-options.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: k8s-isilon
+provisioner: example.com/isilon
+parameters:
+  mountOptions: "nfsvers=3" # this should be a comma separated list of options

--- a/k8s_isi_provisioner.go
+++ b/k8s_isi_provisioner.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"strings"
 	"time"
+	"fmt"
 
 	"syscall"
 
@@ -113,12 +114,24 @@ func (p *isilonProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		return nil, err
 	}
 
+	// Get the mount options of the storage class
+	mountOptions := ""
+	for k, v := range options.Parameters {
+		switch strings.ToLower(k) {
+		case "mountoptions":
+			mountOptions = v
+		default:
+			return nil, fmt.Errorf("invalid parameter: %q", k)
+		}
+	}
+
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: options.PVName,
 			Annotations: map[string]string{
-				"isilonProvisionerIdentity": p.identity,
-				"isilonVolume":              pvName,
+				"isilonProvisionerIdentity": 								p.identity,
+				"isilonVolume":              								pvName,
+				"volume.beta.kubernetes.io/mount-options": 	mountOptions,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{


### PR DESCRIPTION
Some versions of Isilon only work with NFSv3. This mount option is required when creating the storage class. I added support for parsing mount options from the parameters of the storage class and adding them to the PersistentVolume.